### PR TITLE
Respect MineSkin API delay & fix status check

### DIFF
--- a/Libraries/core.js
+++ b/Libraries/core.js
@@ -142,7 +142,7 @@ $("[id^=skintype-]").on("change", function () {
 function checkApiStatus() {
   $.ajax({
     type: 'get',
-    url: 'https://api.mineskin.org/',
+    url: 'https://api.mineskin.org/get/delay',
     dataType: 'json',
     encode: true
   }).fail(function (response) {

--- a/Libraries/core.js
+++ b/Libraries/core.js
@@ -3,33 +3,55 @@ checkApiStatus();
 var fileName;
 var isSlim = false;
 var skinURL;
+var nextRequest = Date.now() + 1000;
 
 function upload(data, retrycount) {
   console.log("try upload to mineskin");
-  $.ajax({
-    type: 'post',
-    url: 'https://api.mineskin.org/generate/upload',
-    data: data,
-    cache: false,
-    processData: false,
-    contentType: false,
-    dataType: 'json',
-    encode: true
-  }).done(function (response) {
-    var signature = response.data.texture.signature;
-    var value = response.data.texture.value;
-    if (signature && value) {
-      swal({
-        type: 'success',
-        title: 'Enjoy your skin',
-        text: 'The System going to download a skin file!'
-      });
-      /* Create File */
-      let fileName = $('#fileName').val().toLowerCase();
-      var blob = new Blob([value + '\n' + signature + '\n' + 4102444800000], { type: "text/plain;charset=utf-8" });
-      saveAs(blob, fileName == '' ? response.id + '.skin' : fileName + '.skin');
-      /* ----------- */
-    } else {
+  setTimeout(function () {
+    $.ajax({
+      type: 'post',
+      url: 'https://api.mineskin.org/generate/upload',
+      data: data,
+      cache: false,
+      processData: false,
+      contentType: false,
+      dataType: 'json',
+      encode: true
+    }).done(function (response) {
+      var signature = response.data.texture.signature;
+      var value = response.data.texture.value;
+      if (response.nextRequest) {
+        nextRequest = Date.now() + (response.nextRequest * 1000);
+      } else {
+        nextRequest = Date.now() + 10000;
+      }
+      if (signature && value) {
+        swal({
+          type: 'success',
+          title: 'Enjoy your skin',
+          text: 'The System going to download a skin file!'
+        });
+        /* Create File */
+        let fileName = $('#fileName').val().toLowerCase();
+        var blob = new Blob([value + '\n' + signature + '\n' + 4102444800000], { type: "text/plain;charset=utf-8" });
+        saveAs(blob, fileName == '' ? response.id + '.skin' : fileName + '.skin');
+        /* ----------- */
+      } else {
+        if (retrycount > 0) {
+          upload(data, retrycount - 1)
+        } else {
+          swal({
+            type: 'error',
+            title: 'Sorry, something went wrong!',
+            text: "Please upload a minecraft's skin or reload the site."
+          });
+        }
+      }
+
+      $('.custom-file-input').val('');
+      $('.custom-file-label').html('Choose skins(s)...');
+    }).fail(function (response) {
+      console.log('Fail : ' + response);
       if (retrycount > 0) {
         upload(data, retrycount - 1)
       } else {
@@ -39,22 +61,8 @@ function upload(data, retrycount) {
           text: "Please upload a minecraft's skin or reload the site."
         });
       }
-    }
-
-    $('.custom-file-input').val('');
-    $('.custom-file-label').html('Choose skins(s)...');
-  }).fail(function (response) {
-    console.log('Fail : ' + response);
-    if (retrycount > 0) {
-      upload(data, retrycount - 1)
-    } else {
-      swal({
-        type: 'error',
-        title: 'Sorry, something went wrong!',
-        text: "Please upload a minecraft's skin or reload the site."
-      });
-    }
-  });
+    });
+  }, Math.max(500, nextRequest - Date.now()));
 }
 
 $('.custom-file-input').on('change', function () {


### PR DESCRIPTION
* Added a base delay of 500ms before sending requests
* Keep track of `nextRequest` returned by the API and wait for that before generating again
* Wait 10s before trying again if there was an error
* Switched status check to use `/get/delay` since `/` is currently causing CORS errors